### PR TITLE
fixes method names being unreadable on solarized light

### DIFF
--- a/config/Editors/FontsColors/Netbeans_Solarized_Light/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
+++ b/config/Editors/FontsColors/Netbeans_Solarized_Light/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
@@ -16,7 +16,7 @@
     <fontcolor foreColor="ff2aa198" name="string"/>
     <fontcolor default="string" name="markup-attribute-value"/>
     <fontcolor default="default" foreColor="magenta" name="entity-reference"/>
-    <fontcolor default="identifier" foreColor="white" name="method"/>
+    <fontcolor default="identifier" name="method"/>
     <fontcolor foreColor="ff93a1a1" name="comment">
         <font style="italic"/>
     </fontcolor>


### PR DESCRIPTION
Changed the color for methods to be the inherited fg/bg color for all text instead of white on the solarized light background.
