### PR TITLE
Add support for Apache Conf Files

### DIFF
--- a/config/Editors/text/x-apache-conf/FontsColors/Netbeans_Solarized_Dark/.nbattrs
+++ b/config/Editors/text/x-apache-conf/FontsColors/Netbeans_Solarized_Dark/.nbattrs
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
+<attributes version="1.0">
+    <fileobject name="org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml">
+        <attr name="nbeditor-settings-ColoringType" stringvalue="token"/>
+    </fileobject>
+</attributes>

--- a/config/Editors/text/x-apache-conf/FontsColors/Netbeans_Solarized_Dark/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
+++ b/config/Editors/text/x-apache-conf/FontsColors/Netbeans_Solarized_Dark/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor default="keyword" foreColor="ff2aa198" name="tagparam"/>
+    <fontcolor default="separator" foreColor="ff628fb5" name="flag"/>
+    <fontcolor default="error" name="error"/>
+    <fontcolor default="keyword" foreColor="ff268bd2" name="tag"/>
+    <fontcolor default="string" foreColor="ffee7700" name="string"/>
+    <fontcolor default="whitespace" name="whitespace"/>
+    <fontcolor default="number" foreColor="magenta" name="number"/>
+    <fontcolor default="keyword" foreColor="ffb58900" name="directive">
+        <font style="bold"/>
+    </fontcolor>
+    <fontcolor default="comment" name="comment"/>
+    <fontcolor default="identifier" foreColor="ff2aa198" name="variable"/>
+    <fontcolor default="keyword" foreColor="ff839496" name="directiveparam"/>
+</fontscolors>

--- a/config/Editors/text/x-ini/FontsColors/Netbeans_Solarized_Dark/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
+++ b/config/Editors/text/x-ini/FontsColors/Netbeans_Solarized_Dark/org-netbeans-modules-editor-settings-CustomFontsColors-tokenColorings.xml
@@ -6,8 +6,12 @@
     <fontcolor foreColor="ff268bc4" name="name"/>
     <fontcolor name="whitespace"/>
     <fontcolor foreColor="ffcb4b16" name="value"/>
+    <fontcolor foreColor="ff509a05" name="section_delim">
+        <font style="bold"/>
+    </fontcolor>
     <fontcolor name="comment"/>
     <fontcolor foreColor="ff859900" name="section">
         <font style="bold"/>
     </fontcolor>
+    <fontcolor foreColor="ff2aa298" name="key"/>
 </fontscolors>


### PR DESCRIPTION
Netbeans 7.2 brings with it support for Apache Conf files so I have added support for it in the Dark theme. I have also included a minor amend to the INI file styles to make the text more readable as it was black for me.

I hope these changes are inline with the solarized theme. The Apache conf colourings where basically mirrored from the XML file theming so it should be good.
